### PR TITLE
fix(worker): run session handlers only on-minute cron

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -13,8 +13,10 @@ export default {
     const { db, client } = createDB(env);
     console.log(`Worker triggered by cron: ${controller.cron}`);
 
-    await handleRecordSessions(db, env);
-    await handleOnlineSessions(db, env);
+    if (controller.cron === '* * * * *') {
+      await handleRecordSessions(db, env);
+      await handleOnlineSessions(db, env);
+    }
 
     if (controller.cron === '*/2 * * * *') {
       await syncDiscord(db, env);


### PR DESCRIPTION
Only invoke handleRecordSessions and handleOnlineSessions when the
controller cron is the per-minute schedule ('* * * * *'). Previously
these handlers ran for every cron invocation, causing duplicate or
unnecessary work on other schedules (for example the 2-minute sync).
This change scopes session handling to the intended frequent tick,
preventing redundant database operations, reducing load, and duplicated notifications.