### PR TITLE
chore: re-enable auto merge for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "packageRules": [],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    }
+  ],
   "prHourlyLimit": 5
 }


### PR DESCRIPTION
Re-enable auto merge for renovate for patches. Keep it disabled for minor changes and above. Consider re-enabling for minor changes depending on success of patches