### PR TITLE
feat: include students with the OBS role in the student Discord role

### DIFF
--- a/apps/worker/src/syncDiscord.ts
+++ b/apps/worker/src/syncDiscord.ts
@@ -106,7 +106,10 @@ export const syncDiscord = async (db: DB, env: Env) => {
       (b.lastSyncedAt ? new Date(b.lastSyncedAt).getTime() : 0)
   );
 
-  const users = await User.fromCids(db, integrations.map((i) => i.cid));
+  const users = await User.fromCids(
+    db,
+    integrations.map((i) => i.cid)
+  );
   const usersByCid = new Map(users.map((u) => [u.cid, u]));
 
   for (const integration of integrations) {
@@ -221,7 +224,7 @@ export const syncDiscord = async (db: DB, env: Env) => {
       }
 
       // student role
-      if (user.hasFlag('controller') && user.rating.id >= 2 && user.rating.id <= 4) {
+      if (user.hasFlag('controller') && user.rating.id >= 1 && user.rating.id <= 4) {
         const role = guildRoles.find((r) => r.name === 'Student');
         if (role) {
           roles.push(role.id);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Discord role-assignment logic, which could unintentionally grant or remove the `Student` role for some members and affect Discord channel access. Scope is small and localized to the worker sync job.
> 
> **Overview**
> Discord sync now assigns the `Student` role to linked users with the `controller` flag and rating IDs `1..4` (previously `2..4`), so OBS-rated controllers are included.
> 
> Also includes a small formatting-only change around the `User.fromCids` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24fb50d40c163c6599af51728365af62668a4854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->