### PR TITLE
Address Copilot review comments on DMS PR

### DIFF
--- a/apps/web/src/lib/remote/dms.remote.ts
+++ b/apps/web/src/lib/remote/dms.remote.ts
@@ -66,9 +66,7 @@ export const getActiveGroups = query(async () => {
       .filter((document) => documentToCurrentAssetId.has(document.id))
       .map((document) => {
         const currentAssetId = documentToCurrentAssetId.get(document.id) ?? null;
-        const acknowledged = currentAssetId
-          ? acknowledgedAssetIds.has(currentAssetId)
-          : false;
+        const acknowledged = currentAssetId ? acknowledgedAssetIds.has(currentAssetId) : false;
 
         return {
           id: document.id,

--- a/apps/web/src/lib/remote/dms.remote.ts
+++ b/apps/web/src/lib/remote/dms.remote.ts
@@ -12,19 +12,83 @@ export const getGroups = query(async () => {
 });
 
 export const getActiveGroups = query(async () => {
-  // get all groups who have at least one document with a current asset
+  const event = getRequestEvent();
+  const sessionToken = event.cookies.get('session') ?? '';
+  const user = sessionToken ? await User.fromSessionToken(db, sessionToken) : null;
+  const canUserAcknowledge = Boolean(user?.hasFlag(['visitor', 'controller']));
+
   const groups = await DmsGroup.fetchAll(db);
-  const activeGroups = [];
 
+  // Collect (documentId -> currentAssetId) for every document that has an active asset,
+  // then look up acknowledgements for the current user in a single query so we don't
+  // fan out one request per document on the client.
+  const documentToCurrentAssetId = new Map<string, string>();
   for (const group of groups) {
-    const documents = await group.documents;
-
-    for (const document of documents) {
+    for (const document of group.documents) {
       const currentAsset = document.getCurrentAsset();
       if (currentAsset) {
-        activeGroups.push(group);
-        break;
+        documentToCurrentAssetId.set(document.id, currentAsset.id);
       }
+    }
+  }
+
+  const acknowledgedAssetIds = new Set<string>();
+  if (canUserAcknowledge && user && documentToCurrentAssetId.size > 0) {
+    const currentAssetIds = Array.from(new Set(documentToCurrentAssetId.values()));
+    const acknowledgements = await db.query.dmsAcknowledgements.findMany({
+      where: {
+        assetId: { in: currentAssetIds },
+        userId: String(user.cid)
+      },
+      columns: { assetId: true }
+    });
+    for (const ack of acknowledgements) {
+      acknowledgedAssetIds.add(ack.assetId);
+    }
+  }
+  const activeGroups: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    sort: number;
+    documents: Array<{
+      id: string;
+      short: string;
+      name: string;
+      description: string | null;
+      required: boolean;
+      canAcknowledge: boolean;
+    }>;
+  }> = [];
+
+  for (const group of groups) {
+    const documents = group.documents
+      .filter((document) => documentToCurrentAssetId.has(document.id))
+      .map((document) => {
+        const currentAssetId = documentToCurrentAssetId.get(document.id) ?? null;
+        const acknowledged = currentAssetId
+          ? acknowledgedAssetIds.has(currentAssetId)
+          : false;
+
+        return {
+          id: document.id,
+          short: document.short,
+          name: document.name,
+          description: document.description,
+          required: document.required,
+          canAcknowledge:
+            canUserAcknowledge && document.required && currentAssetId !== null && !acknowledged
+        };
+      });
+
+    if (documents.length > 0) {
+      activeGroups.push({
+        id: group.id,
+        slug: group.slug,
+        name: group.name,
+        sort: group.sort,
+        documents
+      });
     }
   }
 
@@ -89,6 +153,7 @@ export const acknowledgeDocument = command(type('string'), async (documentId) =>
   try {
     const acknowledgement = await document.acknowledgeCurrentAsset(user.cid);
     getDocumentAcknowledgement(documentId).refresh();
+    getActiveGroups().refresh();
 
     return {
       ok: true,

--- a/apps/web/src/lib/utilities/dms.server.ts
+++ b/apps/web/src/lib/utilities/dms.server.ts
@@ -53,7 +53,6 @@ export async function streamDmsAsset(
     throw error(404, 'Asset file not found');
   }
 
-  const bytes = await assetObject.Body.transformToByteArray();
   const headers = new Headers({
     'Content-Type': assetObject.ContentType ?? 'application/octet-stream',
     'Cache-Control': 'public, max-age=60'
@@ -63,6 +62,22 @@ export async function streamDmsAsset(
     headers.set('Content-Length', String(assetObject.ContentLength));
   }
 
+  const body = assetObject.Body as unknown as {
+    transformToWebStream?: () => ReadableStream<Uint8Array>;
+    transformToByteArray: () => Promise<Uint8Array>;
+  };
+
+  // Prefer streaming the SDK body directly (web ReadableStream on Cloudflare Workers /
+  // browser-like runtimes) so large PDFs aren't fully buffered into memory. Fall back
+  // to buffering only when the runtime doesn't expose a web stream.
+  if (typeof body.transformToWebStream === 'function') {
+    return new Response(body.transformToWebStream(), {
+      status: 200,
+      headers
+    });
+  }
+
+  const bytes = await body.transformToByteArray();
   return new Response(bytes, {
     status: 200,
     headers

--- a/apps/web/src/routes/docs/+page.svelte
+++ b/apps/web/src/routes/docs/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getActiveGroups, getDocumentAcknowledgement } from '$lib/remote/dms.remote';
+  import { getActiveGroups } from '$lib/remote/dms.remote';
 </script>
 
 <section id="join" class="min-h-screen">
@@ -27,13 +27,11 @@
                       <div class="flex flex-col gap-1">
                         <div class="flex flex-wrap items-center gap-2">
                           <span>{doc.name}</span>
-                          {#await getDocumentAcknowledgement(doc.id) then acknowledgement}
-                            {#if acknowledgement.canAcknowledge}
-                              <span class="badge badge-warning badge-sm"
-                                >Acknowledgement required</span
-                              >
-                            {/if}
-                          {/await}
+                          {#if doc.canAcknowledge}
+                            <span class="badge badge-warning badge-sm"
+                              >Acknowledgement required</span
+                            >
+                          {/if}
                         </div>
                         <span class="text-base-content/60">{doc.description}</span>
                       </div>

--- a/apps/web/src/routes/docs/+page.svelte
+++ b/apps/web/src/routes/docs/+page.svelte
@@ -19,8 +19,11 @@
               <h2 class="mb-5 text-lg font-semibold">{group.name}</h2>
               <ul class="flex flex-col gap-3">
                 {#each group.documents as doc (doc.short)}
-                  <a href="/docs/{group.slug}/{doc.short}">
-                    <li class="card bg-base-100 flex flex-row justify-between gap-3 p-3">
+                  <li class="card bg-base-100 p-0">
+                    <a
+                      href="/docs/{group.slug}/{doc.short}"
+                      class="flex flex-row justify-between gap-3 p-3"
+                    >
                       <div class="flex flex-col gap-1">
                         <div class="flex flex-wrap items-center gap-2">
                           <span>{doc.name}</span>
@@ -34,8 +37,8 @@
                         </div>
                         <span class="text-base-content/60">{doc.description}</span>
                       </div>
-                    </li>
-                  </a>
+                    </a>
+                  </li>
                 {/each}
               </ul>
             </li>

--- a/apps/wiki/docs/dms/index.md
+++ b/apps/wiki/docs/dms/index.md
@@ -37,9 +37,9 @@ Once on the document's page, there will be a button available to click which wil
 
 ### Notifications
 
-In order to ensure that controllers review new policy items in a timely fassion, a notification will be sent to controllers via Discord when they connect to the network with an outstanding document. This is there to ensure that documents are reviewed in a timely fassions to ensure that we are able to provide the best of service on the VATSIM network.
+In order to ensure that controllers review new policy items in a timely fashion, a notification will be sent to controllers via Discord when they connect to the network with an outstanding document. This is there to ensure that documents are reviewed in a timely fashion to ensure that we are able to provide the best of service on the VATSIM network.
 
-These notifications are mandarotry notifications which cannot be dissabled. In order to silence them, you must [acknowledge the document](#acknowledging-documents).
+These notifications are mandatory notifications which cannot be disabled. In order to silence them, you must [acknowledge the document](#acknowledging-documents).
 
 ## How to use the DMS as a staff member
 
@@ -55,7 +55,7 @@ Once inside of a group, you can use the blue "Create Document" button to create 
 - **Required** - If this document is required for controllers to acknowledge
 - **Sort Order** - Documents are sorted within their groups first from 0-99 of the sort order value then alphabetically
 
-Once that is completed, you can use the "Create Document" button to finallize the document creation.
+Once that is completed, you can use the "Create Document" button to finalize the document creation.
 
 Now that the document has been created, you must add an asset. An asset represents each version of the document.
 

--- a/packages/common/src/models/dms.ts
+++ b/packages/common/src/models/dms.ts
@@ -777,38 +777,40 @@ export class DmsGroup {
         db,
       );
 
-      dmsGroup.documents = group.documents.map(
-        (document) =>
-          new DmsDocument(
-            {
-              id: document.id,
-              required: document.required,
-              name: document.name,
-              description: document.description,
-              groupId: document.groupId,
-              short: document.short,
-              sort: document.sort ?? 99,
-              group: dmsGroup,
-              assets: document.assets.map(
-                (asset) =>
-                  new DmsAsset(
-                    {
-                      id: asset.id,
-                      documentId: asset.documentId,
-                      version: asset.version,
-                      effectiveDate: asset.effectiveDate,
-                      expiryDate: asset.expiryDate,
-                      public: asset.public,
-                      url: asset.url,
-                      document: null as any,
-                    },
-                    db,
-                  ),
-              ),
-            },
-            db,
-          ),
-      );
+      dmsGroup.documents = group.documents.map((document) => {
+        const dmsDocument = new DmsDocument(
+          {
+            id: document.id,
+            required: document.required,
+            name: document.name,
+            description: document.description,
+            groupId: document.groupId,
+            short: document.short,
+            sort: document.sort ?? 99,
+            group: dmsGroup,
+          },
+          db,
+        );
+
+        dmsDocument.assets = document.assets.map(
+          (asset) =>
+            new DmsAsset(
+              {
+                id: asset.id,
+                documentId: asset.documentId,
+                version: asset.version,
+                effectiveDate: asset.effectiveDate,
+                expiryDate: asset.expiryDate,
+                public: asset.public,
+                url: asset.url,
+                document: dmsDocument,
+              },
+              db,
+            ),
+        );
+
+        return dmsDocument;
+      });
 
       return dmsGroup;
     });

--- a/packages/common/src/models/dms.ts
+++ b/packages/common/src/models/dms.ts
@@ -401,32 +401,56 @@ export class DmsDocument {
     }>
   > {
     const documents = await DmsDocument.fetchAll(db);
-    const pending: Array<{
-      id: string;
-      name: string;
-      short: string;
-      groupSlug: string | null;
-      assetVersion: string;
-      url: string;
-    }> = [];
 
+    type PendingCandidate = {
+      doc: DmsDocument;
+      currentAsset: DmsAsset;
+      groupSlug: string;
+    };
+
+    const candidates: PendingCandidate[] = [];
     for (const doc of documents) {
       if (!doc.required) continue;
+
+      const groupSlug = doc.group?.slug;
+      if (!groupSlug) continue;
+
       const currentAsset = doc.getCurrentAsset(now);
       if (!currentAsset) continue;
-      const ack = await doc.getAcknowledgementForCurrentAsset(userCid, now);
-      if (ack) continue;
-      pending.push({
-        id: doc.id,
-        name: doc.name,
-        short: doc.short,
-        groupSlug: doc.group?.slug ?? null,
-        assetVersion: currentAsset.version,
-        url: `/docs/${doc.group?.slug}/${doc.short}`,
-      });
+
+      candidates.push({ doc, currentAsset, groupSlug });
     }
 
-    return pending;
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    // Batch a single acknowledgement lookup across every current asset to avoid an
+    // N+1 query per document, which previously ran on every controller connect.
+    const currentAssetIds = Array.from(
+      new Set(candidates.map((candidate) => candidate.currentAsset.id)),
+    );
+    const acknowledgements = await db.query.dmsAcknowledgements.findMany({
+      where: {
+        assetId: { in: currentAssetIds },
+        userId: String(userCid),
+      },
+      columns: { assetId: true },
+    });
+    const acknowledgedAssetIds = new Set(
+      acknowledgements.map((acknowledgement) => acknowledgement.assetId),
+    );
+
+    return candidates
+      .filter((candidate) => !acknowledgedAssetIds.has(candidate.currentAsset.id))
+      .map((candidate) => ({
+        id: candidate.doc.id,
+        name: candidate.doc.name,
+        short: candidate.doc.short,
+        groupSlug: candidate.groupSlug,
+        assetVersion: candidate.currentAsset.version,
+        url: `/docs/${candidate.groupSlug}/${candidate.doc.short}`,
+      }));
   }
 
   static async create(db: DB, data: CreateDmsDocumentInput) {

--- a/packages/common/src/models/dms.ts
+++ b/packages/common/src/models/dms.ts
@@ -98,6 +98,48 @@ export class DmsAcknowledgeError extends Error {
   }
 }
 
+/**
+ * Detects a SQLite UNIQUE constraint violation across the libsql driver shapes
+ * we see in practice. Prefers the structured error code/cause exposed by libsql
+ * over string-matching the raw message.
+ */
+const isUniqueConstraintError = (error: unknown): boolean => {
+  const codes = new Set<string>();
+  const messages: string[] = [];
+
+  const collect = (candidate: unknown) => {
+    if (!candidate || typeof candidate !== "object") return;
+    const record = candidate as { code?: unknown; message?: unknown };
+    if (typeof record.code === "string") {
+      codes.add(record.code);
+    }
+    if (typeof record.message === "string") {
+      messages.push(record.message);
+    }
+  };
+
+  collect(error);
+  if (error && typeof error === "object" && "cause" in error) {
+    collect((error as { cause: unknown }).cause);
+  }
+
+  for (const code of codes) {
+    if (
+      code === "SQLITE_CONSTRAINT" ||
+      code === "SQLITE_CONSTRAINT_UNIQUE" ||
+      code === "SQLITE_CONSTRAINT_PRIMARYKEY"
+    ) {
+      return true;
+    }
+  }
+
+  return messages.some(
+    (message) =>
+      message.includes("UNIQUE constraint failed") ||
+      message.includes("dms_acknowledgements_user_asset_unique_idx"),
+  );
+};
+
 const toDate = (value: Date | string | null | undefined) => {
   if (!value) {
     return null;
@@ -586,10 +628,7 @@ export class DmsDocument {
         assetId: currentAsset.id,
       };
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("dms_acknowledgements_user_asset_unique_idx")
-      ) {
+      if (isUniqueConstraintError(error)) {
         throw new DmsAcknowledgeError(
           "ALREADY_ACKNOWLEDGED",
           "You have already acknowledged the current document asset.",

--- a/packages/db/migrations/20260501003817_fine_spectrum/migration.sql
+++ b/packages/db/migrations/20260501003817_fine_spectrum/migration.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `dms_documents_group_id_short_unique_idx` ON `dms_documents` (`groupId`,`short`);

--- a/packages/db/migrations/20260501003817_fine_spectrum/snapshot.json
+++ b/packages/db/migrations/20260501003817_fine_spectrum/snapshot.json
@@ -1,0 +1,3238 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "6cc8d7a0-0beb-4d6f-9147-427175a0aca4",
+  "prevIds": [
+    "b738ed73-2834-47c0-9760-e6b399192295"
+  ],
+  "ddl": [
+    {
+      "name": "flags",
+      "entityType": "tables"
+    },
+    {
+      "name": "ratings",
+      "entityType": "tables"
+    },
+    {
+      "name": "user_flags",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "name": "events",
+      "entityType": "tables"
+    },
+    {
+      "name": "news",
+      "entityType": "tables"
+    },
+    {
+      "name": "positions",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "auth_sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "ticket_messages",
+      "entityType": "tables"
+    },
+    {
+      "name": "ticket_types",
+      "entityType": "tables"
+    },
+    {
+      "name": "tickets",
+      "entityType": "tables"
+    },
+    {
+      "name": "resources",
+      "entityType": "tables"
+    },
+    {
+      "name": "solo_endorsements",
+      "entityType": "tables"
+    },
+    {
+      "name": "roster",
+      "entityType": "tables"
+    },
+    {
+      "name": "integrations",
+      "entityType": "tables"
+    },
+    {
+      "name": "preferences",
+      "entityType": "tables"
+    },
+    {
+      "name": "online_sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "enrolled_users",
+      "entityType": "tables"
+    },
+    {
+      "name": "waiting_users",
+      "entityType": "tables"
+    },
+    {
+      "name": "waitlists",
+      "entityType": "tables"
+    },
+    {
+      "name": "moodle_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "notifications",
+      "entityType": "tables"
+    },
+    {
+      "name": "jobs",
+      "entityType": "tables"
+    },
+    {
+      "name": "dms_acknowledgements",
+      "entityType": "tables"
+    },
+    {
+      "name": "dms_assets",
+      "entityType": "tables"
+    },
+    {
+      "name": "dms_documents",
+      "entityType": "tables"
+    },
+    {
+      "name": "dms_groups",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "flags"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "flags"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "showInSelect",
+      "entityType": "columns",
+      "table": "flags"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "ratings"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "long",
+      "entityType": "columns",
+      "table": "ratings"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "short",
+      "entityType": "columns",
+      "table": "ratings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "flag_id",
+      "entityType": "columns",
+      "table": "user_flags"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "user_flags"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cid",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name_first",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name_last",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name_full",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ratingID",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "division",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "region",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "subdivision",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "bio",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discord_id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "hoursLastUpdated",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "end",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "recurring",
+      "entityType": "columns",
+      "table": "events"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "news"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "news"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "news"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "date",
+      "entityType": "columns",
+      "table": "news"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "author_id",
+      "entityType": "columns",
+      "table": "news"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "news"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "positions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "callsign",
+      "entityType": "columns",
+      "table": "positions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frequency",
+      "entityType": "columns",
+      "table": "positions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "positions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "positionId",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "logonTime",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ratingId",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "aircraftTracked",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "aircraftSeen",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "flightsAmended",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "handoffsInitiated",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "handoffsReceived",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "handoffsRefused",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "squawksAssigned",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cruiseAltsModified",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "tempAltsModified",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "scratchpadMods",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "auth_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "auth_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "auth_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "ticket_messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ticket_id",
+      "entityType": "columns",
+      "table": "ticket_messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "author_id",
+      "entityType": "columns",
+      "table": "ticket_messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message",
+      "entityType": "columns",
+      "table": "ticket_messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "ticket_messages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "ticket_types"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "ticket_types"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "subject",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "author_id",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type_id",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'open'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "tickets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "public",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "resources"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "solo_endorsements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "controller_id",
+      "entityType": "columns",
+      "table": "solo_endorsements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "solo_endorsements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position_id",
+      "entityType": "columns",
+      "table": "solo_endorsements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "roster"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "controller_id",
+      "entityType": "columns",
+      "table": "roster"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "roster"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "roster"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "integrations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "integrations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "integration_user_id",
+      "entityType": "columns",
+      "table": "integrations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cid",
+      "entityType": "columns",
+      "table": "integrations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "integration_user_name",
+      "entityType": "columns",
+      "table": "integrations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_synced_at",
+      "entityType": "columns",
+      "table": "integrations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "preferences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cid",
+      "entityType": "columns",
+      "table": "preferences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "preferences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "preferences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "online_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "online_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "positionId",
+      "entityType": "columns",
+      "table": "online_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "online_sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "enrolled_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cid",
+      "entityType": "columns",
+      "table": "enrolled_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "waitlist_id",
+      "entityType": "columns",
+      "table": "enrolled_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "enrolled_at",
+      "entityType": "columns",
+      "table": "enrolled_users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "hidden_at",
+      "entityType": "columns",
+      "table": "enrolled_users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "waiting_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cid",
+      "entityType": "columns",
+      "table": "waiting_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "waitlist_id",
+      "entityType": "columns",
+      "table": "waiting_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "waiting_users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "waiting_since",
+      "entityType": "columns",
+      "table": "waiting_users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "waitlists"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "waitlists"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wait_time",
+      "entityType": "columns",
+      "table": "waitlists"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "waitlist_cohort",
+      "entityType": "columns",
+      "table": "waitlists"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "enrolled_cohort",
+      "entityType": "columns",
+      "table": "waitlists"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "moodle_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cid",
+      "entityType": "columns",
+      "table": "moodle_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cohort_id",
+      "entityType": "columns",
+      "table": "moodle_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "table": "moodle_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "add",
+      "entityType": "columns",
+      "table": "moodle_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sent",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "buttons",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'email'",
+      "generated": null,
+      "name": "location",
+      "entityType": "columns",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scheduledTime",
+      "entityType": "columns",
+      "table": "jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "executedTime",
+      "entityType": "columns",
+      "table": "jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "assetId",
+      "entityType": "columns",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "userId",
+      "entityType": "columns",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "acknowledgedAt",
+      "entityType": "columns",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "documentId",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "effectiveDate",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expiryDate",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "public",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "dms_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "required",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "groupId",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "short",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "99",
+      "generated": null,
+      "name": "sort",
+      "entityType": "columns",
+      "table": "dms_documents"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "dms_groups"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "dms_groups"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "99",
+      "generated": null,
+      "name": "sort",
+      "entityType": "columns",
+      "table": "dms_groups"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "dms_groups"
+    },
+    {
+      "columns": [
+        "flag_id"
+      ],
+      "tableTo": "flags",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "user_flags_flag_id_flags_id_fk",
+      "entityType": "fks",
+      "table": "user_flags"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "user_flags_user_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "user_flags"
+    },
+    {
+      "columns": [
+        "ratingID"
+      ],
+      "tableTo": "ratings",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "users_ratingID_ratings_id_fk",
+      "entityType": "fks",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "author_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "news_author_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "news"
+    },
+    {
+      "columns": [
+        "userId"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sessions_userId_users_cid_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "positionId"
+      ],
+      "tableTo": "positions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sessions_positionId_positions_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "ratingId"
+      ],
+      "tableTo": "ratings",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "sessions_ratingId_ratings_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "auth_sessions_user_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "auth_sessions"
+    },
+    {
+      "columns": [
+        "ticket_id"
+      ],
+      "tableTo": "tickets",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "ticket_messages_ticket_id_tickets_id_fk",
+      "entityType": "fks",
+      "table": "ticket_messages"
+    },
+    {
+      "columns": [
+        "author_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "ticket_messages_author_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "ticket_messages"
+    },
+    {
+      "columns": [
+        "author_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "tickets_author_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "tickets"
+    },
+    {
+      "columns": [
+        "type_id"
+      ],
+      "tableTo": "ticket_types",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "tickets_type_id_ticket_types_id_fk",
+      "entityType": "fks",
+      "table": "tickets"
+    },
+    {
+      "columns": [
+        "controller_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "solo_endorsements_controller_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "solo_endorsements"
+    },
+    {
+      "columns": [
+        "position_id"
+      ],
+      "tableTo": "positions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "solo_endorsements_position_id_positions_id_fk",
+      "entityType": "fks",
+      "table": "solo_endorsements"
+    },
+    {
+      "columns": [
+        "controller_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "roster_controller_id_users_cid_fk",
+      "entityType": "fks",
+      "table": "roster"
+    },
+    {
+      "columns": [
+        "cid"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "integrations_cid_users_cid_fk",
+      "entityType": "fks",
+      "table": "integrations"
+    },
+    {
+      "columns": [
+        "cid"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "preferences_cid_users_cid_fk",
+      "entityType": "fks",
+      "table": "preferences"
+    },
+    {
+      "columns": [
+        "cid"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "enrolled_users_cid_users_cid_fk",
+      "entityType": "fks",
+      "table": "enrolled_users"
+    },
+    {
+      "columns": [
+        "waitlist_id"
+      ],
+      "tableTo": "waitlists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "enrolled_users_waitlist_id_waitlists_id_fk",
+      "entityType": "fks",
+      "table": "enrolled_users"
+    },
+    {
+      "columns": [
+        "cid"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "waiting_users_cid_users_cid_fk",
+      "entityType": "fks",
+      "table": "waiting_users"
+    },
+    {
+      "columns": [
+        "waitlist_id"
+      ],
+      "tableTo": "waitlists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "waiting_users_waitlist_id_waitlists_id_fk",
+      "entityType": "fks",
+      "table": "waiting_users"
+    },
+    {
+      "columns": [
+        "cid"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "moodle_queue_cid_users_cid_fk",
+      "entityType": "fks",
+      "table": "moodle_queue"
+    },
+    {
+      "columns": [
+        "userId"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "nameExplicit": false,
+      "name": "notifications_userId_users_cid_fk",
+      "entityType": "fks",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        "assetId"
+      ],
+      "tableTo": "dms_assets",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_dms_acknowledgements_assetId_dms_assets_id_fk",
+      "entityType": "fks",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "columns": [
+        "userId"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "cid"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_dms_acknowledgements_userId_users_cid_fk",
+      "entityType": "fks",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "columns": [
+        "documentId"
+      ],
+      "tableTo": "dms_documents",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "dms_assets_documentId_dms_documents_id_fk",
+      "entityType": "fks",
+      "table": "dms_assets"
+    },
+    {
+      "columns": [
+        "groupId"
+      ],
+      "tableTo": "dms_groups",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_dms_documents_groupId_dms_groups_id_fk",
+      "entityType": "fks",
+      "table": "dms_documents"
+    },
+    {
+      "columns": [
+        "user_id",
+        "flag_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_flags_user_id_flag_id_pk",
+      "entityType": "pks",
+      "table": "user_flags"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "flags_pk",
+      "table": "flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "ratings_pk",
+      "table": "ratings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "cid"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "events_pk",
+      "table": "events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "news_pk",
+      "table": "news",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "positions_pk",
+      "table": "positions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "auth_sessions_pk",
+      "table": "auth_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "ticket_messages_pk",
+      "table": "ticket_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "ticket_types_pk",
+      "table": "ticket_types",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "tickets_pk",
+      "table": "tickets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "resources_pk",
+      "table": "resources",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "solo_endorsements_pk",
+      "table": "solo_endorsements",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "roster_pk",
+      "table": "roster",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "integrations_pk",
+      "table": "integrations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "preferences_pk",
+      "table": "preferences",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "online_sessions_pk",
+      "table": "online_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "enrolled_users_pk",
+      "table": "enrolled_users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "waiting_users_pk",
+      "table": "waiting_users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "waitlists_pk",
+      "table": "waitlists",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "moodle_queue_pk",
+      "table": "moodle_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pk",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "jobs_pk",
+      "table": "jobs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dms_acknowledgements_pk",
+      "table": "dms_acknowledgements",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dms_assets_pk",
+      "table": "dms_assets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dms_documents_pk",
+      "table": "dms_documents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dms_groups_pk",
+      "table": "dms_groups",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "flags_name_idx",
+      "entityType": "indexes",
+      "table": "flags"
+    },
+    {
+      "columns": [
+        {
+          "value": "long",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "ratings_long_idx",
+      "entityType": "indexes",
+      "table": "ratings"
+    },
+    {
+      "columns": [
+        {
+          "value": "short",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "ratings_short_idx",
+      "entityType": "indexes",
+      "table": "ratings"
+    },
+    {
+      "columns": [
+        {
+          "value": "flag_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "user_flags_flagId_idx",
+      "entityType": "indexes",
+      "table": "user_flags"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "user_flags_userId_idx",
+      "entityType": "indexes",
+      "table": "user_flags"
+    },
+    {
+      "columns": [
+        {
+          "value": "ratingID",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "users_ratingID_idx",
+      "entityType": "indexes",
+      "table": "users"
+    },
+    {
+      "columns": [
+        {
+          "value": "discord_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "users_discord_id_idx",
+      "entityType": "indexes",
+      "table": "users"
+    },
+    {
+      "columns": [
+        {
+          "value": "active",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "users_active_idx",
+      "entityType": "indexes",
+      "table": "users"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "events_name_idx",
+      "entityType": "indexes",
+      "table": "events"
+    },
+    {
+      "columns": [
+        {
+          "value": "start",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "events_start_idx",
+      "entityType": "indexes",
+      "table": "events"
+    },
+    {
+      "columns": [
+        {
+          "value": "end",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "events_end_idx",
+      "entityType": "indexes",
+      "table": "events"
+    },
+    {
+      "columns": [
+        {
+          "value": "author_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "news_authorID_idx",
+      "entityType": "indexes",
+      "table": "news"
+    },
+    {
+      "columns": [
+        {
+          "value": "date",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "news_date_idx",
+      "entityType": "indexes",
+      "table": "news"
+    },
+    {
+      "columns": [
+        {
+          "value": "title",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "news_title_idx",
+      "entityType": "indexes",
+      "table": "news"
+    },
+    {
+      "columns": [
+        {
+          "value": "frequency",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "positions_frequency_idx",
+      "entityType": "indexes",
+      "table": "positions"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "positions_name_idx",
+      "entityType": "indexes",
+      "table": "positions"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "positionId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_positionId_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "logonTime",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_logonTime_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "auth_sessions_userId_idx",
+      "entityType": "indexes",
+      "table": "auth_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "auth_sessions_expiresAt_idx",
+      "entityType": "indexes",
+      "table": "auth_sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "ticket_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "ticket_messages_ticketId_idx",
+      "entityType": "indexes",
+      "table": "ticket_messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "author_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "ticket_messages_authorId_idx",
+      "entityType": "indexes",
+      "table": "ticket_messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "ticket_messages_createdAt_idx",
+      "entityType": "indexes",
+      "table": "ticket_messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "ticket_types_name_idx",
+      "entityType": "indexes",
+      "table": "ticket_types"
+    },
+    {
+      "columns": [
+        {
+          "value": "author_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "tickets_authorId_idx",
+      "entityType": "indexes",
+      "table": "tickets"
+    },
+    {
+      "columns": [
+        {
+          "value": "type_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "tickets_typeId_idx",
+      "entityType": "indexes",
+      "table": "tickets"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "tickets_status_idx",
+      "entityType": "indexes",
+      "table": "tickets"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "tickets_createdAt_idx",
+      "entityType": "indexes",
+      "table": "tickets"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "resources_name_idx",
+      "entityType": "indexes",
+      "table": "resources"
+    },
+    {
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "resources_category_idx",
+      "entityType": "indexes",
+      "table": "resources"
+    },
+    {
+      "columns": [
+        {
+          "value": "public",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "resources_public_idx",
+      "entityType": "indexes",
+      "table": "resources"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "resources_type_idx",
+      "entityType": "indexes",
+      "table": "resources"
+    },
+    {
+      "columns": [
+        {
+          "value": "controller_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "controller_id_idx",
+      "entityType": "indexes",
+      "table": "solo_endorsements"
+    },
+    {
+      "columns": [
+        {
+          "value": "controller_id",
+          "isExpression": false
+        },
+        {
+          "value": "position_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "controller_position_idx",
+      "entityType": "indexes",
+      "table": "solo_endorsements"
+    },
+    {
+      "columns": [
+        {
+          "value": "controller_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "roster_controllerId_idx",
+      "entityType": "indexes",
+      "table": "roster"
+    },
+    {
+      "columns": [
+        {
+          "value": "position",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "roster_position_idx",
+      "entityType": "indexes",
+      "table": "roster"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "roster_status_idx",
+      "entityType": "indexes",
+      "table": "roster"
+    },
+    {
+      "columns": [
+        {
+          "value": "cid",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "integrations_cid_idx",
+      "entityType": "indexes",
+      "table": "integrations"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "integrations_type_idx",
+      "entityType": "indexes",
+      "table": "integrations"
+    },
+    {
+      "columns": [
+        {
+          "value": "integration_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "integrations_integrationUserId_idx",
+      "entityType": "indexes",
+      "table": "integrations"
+    },
+    {
+      "columns": [
+        {
+          "value": "cid",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "preferences_cid_idx",
+      "entityType": "indexes",
+      "table": "preferences"
+    },
+    {
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "preferences_key_idx",
+      "entityType": "indexes",
+      "table": "preferences"
+    },
+    {
+      "columns": [
+        {
+          "value": "cid",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "enrolled_users_cid_idx",
+      "entityType": "indexes",
+      "table": "enrolled_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "waitlist_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "enrolled_users_waitlistId_idx",
+      "entityType": "indexes",
+      "table": "enrolled_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "enrolled_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "enrolled_users_enrolledAt_idx",
+      "entityType": "indexes",
+      "table": "enrolled_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "hidden_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "enrolled_users_hidden_at_idx",
+      "entityType": "indexes",
+      "table": "enrolled_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "cid",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "waiting_users_cid_idx",
+      "entityType": "indexes",
+      "table": "waiting_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "waitlist_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "waiting_users_waitlistId_idx",
+      "entityType": "indexes",
+      "table": "waiting_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "position",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "waiting_users_position_idx",
+      "entityType": "indexes",
+      "table": "waiting_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "waiting_since",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "waiting_users_waitingSince_idx",
+      "entityType": "indexes",
+      "table": "waiting_users"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "notifications_user_id_idx",
+      "entityType": "indexes",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "timestamp",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "notifications_timestamp_idx",
+      "entityType": "indexes",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        },
+        {
+          "value": "timestamp",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "notifications_user_timestamp_idx",
+      "entityType": "indexes",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        },
+        {
+          "value": "assetId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_acknowledgements_user_asset_unique_idx",
+      "entityType": "indexes",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "columns": [
+        {
+          "value": "assetId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_acknowledgements_asset_id_idx",
+      "entityType": "indexes",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_acknowledgements_user_id_idx",
+      "entityType": "indexes",
+      "table": "dms_acknowledgements"
+    },
+    {
+      "columns": [
+        {
+          "value": "documentId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_assets_document_id_idx",
+      "entityType": "indexes",
+      "table": "dms_assets"
+    },
+    {
+      "columns": [
+        {
+          "value": "effectiveDate",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_assets_effective_date_idx",
+      "entityType": "indexes",
+      "table": "dms_assets"
+    },
+    {
+      "columns": [
+        {
+          "value": "groupId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_documents_group_id_idx",
+      "entityType": "indexes",
+      "table": "dms_documents"
+    },
+    {
+      "columns": [
+        {
+          "value": "groupId",
+          "isExpression": false
+        },
+        {
+          "value": "short",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "dms_documents_group_id_short_unique_idx",
+      "entityType": "indexes",
+      "table": "dms_documents"
+    },
+    {
+      "columns": [
+        "cid",
+        "type"
+      ],
+      "nameExplicit": false,
+      "name": "integrations_cid_type_unique",
+      "entityType": "uniques",
+      "table": "integrations"
+    },
+    {
+      "columns": [
+        "cid",
+        "key"
+      ],
+      "nameExplicit": true,
+      "name": "preferences_cid_key_unique",
+      "entityType": "uniques",
+      "table": "preferences"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "callsign"
+      ],
+      "nameExplicit": false,
+      "name": "positions_callsign_unique",
+      "entityType": "uniques",
+      "table": "positions"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "dms_groups_slug_unique",
+      "entityType": "uniques",
+      "table": "dms_groups"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/schema/documentManagementSystem.ts
+++ b/packages/db/src/schema/documentManagementSystem.ts
@@ -21,7 +21,13 @@ export const dmsDocuments = sqliteTable(
     short: text().notNull(),
     sort: int().notNull().default(99),
   },
-  (table) => [index("dms_documents_group_id_idx").on(table.groupId)],
+  (table) => [
+    index("dms_documents_group_id_idx").on(table.groupId),
+    uniqueIndex("dms_documents_group_id_short_unique_idx").on(
+      table.groupId,
+      table.short,
+    ),
+  ],
 );
 export type DmsDocument = InferSelectModel<typeof dmsDocuments>;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the Copilot review on #134 (4 inline + 8 suppressed comments).

## Inline comments

- **Stream PDFs instead of buffering** (`apps/web/src/lib/utilities/dms.server.ts`) — replaced `transformToByteArray()` with `transformToWebStream()` so large DMS PDFs are streamed straight from R2 to the client. Falls back to buffering only if the runtime doesn't expose a web stream.
- **Invalid `<ul>`/`<a>`/`<li>` nesting** (`apps/web/src/routes/docs/+page.svelte`) — restructured so `<li>` is a direct child of `<ul>` and contains the `<a>`.
- **N+1 acknowledgement requests on `/docs`** — `getActiveGroups` now does a single batched `dmsAcknowledgements.findMany({ where: { assetId: in [...], userId } })` and returns a precomputed `canAcknowledge` per document. The page no longer fans out one `getDocumentAcknowledgement` request per row. `acknowledgeDocument` also refreshes `getActiveGroups` so the badge updates after acknowledgement.

## Suppressed comments

- **`getPendingForUser` URL bug + N+1** (`packages/common/src/models/dms.ts`) — skips documents without a loaded group/slug (no more `/docs/undefined/...`) and batches a single acknowledgement query across all current asset IDs instead of one per document. This runs on every controller connect in `apps/worker/src/onlineATC.ts`, so it matters.
- **`document: null as any`** — replaced with two-pass construction in `DmsGroup.fetchAll` so each `DmsAsset` gets its real `DmsDocument` reference. Prevents future runtime crashes if those assets are ever encoded via the `DmsAsset` transport (which dereferences `asset.document.id`).
- **Brittle uniqueness-conflict detection** — `acknowledgeCurrentAsset` now checks the libsql structured error code (`SQLITE_CONSTRAINT` / `SQLITE_CONSTRAINT_UNIQUE`) on `error` and `error.cause` before falling back to message-based matching.
- **Missing DB-level uniqueness on `(groupId, short)`** — added `uniqueIndex("dms_documents_group_id_short_unique_idx")` to `dmsDocuments` and generated migration `20260501003817_fine_spectrum`. App-side checks can't race-safely guarantee uniqueness on these route identifiers.
- **Wiki typos** (`apps/wiki/docs/dms/index.md`) — `fassion` → `fashion`, `mandarotry` → `mandatory`, `dissabled` → `disabled`, `finallize` → `finalize`.

## Verification

- `pnpm exec tsc --noEmit` clean for `packages/common` and `apps/worker`.
- `pnpm run check` clean for `apps/overseer`.
- `pnpm run check` for `apps/web` shows only pre-existing errors on the base branch (missing env types, unrelated to these changes).
- `drizzle-kit generate` produced exactly one new migration: `CREATE UNIQUE INDEX dms_documents_group_id_short_unique_idx ON dms_documents (groupId, short);`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3137fe08-55b7-4f89-b18d-10317e8d8e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3137fe08-55b7-4f89-b18d-10317e8d8e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

